### PR TITLE
Commands

### DIFF
--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -8,8 +8,12 @@ endif
 
 
 if g:pyrepl_map_keys
-	nnoremap <buffer> <silent> <leader>r :call pyrepl#EvalBuffer()<CR>
-	nnoremap <buffer> <silent> <leader>c :call pyrepl#StripOutput()<CR>
+	nnoremap <buffer> <silent> <leader>ee :PyReplEval<CR>
+	nnoremap <buffer> <silent> <leader>eu :0,PyReplEval<CR>
+	vnoremap <buffer> <silent> <leader>e :'<,'>PyReplEval<CR>
+
+	nnoremap <buffer> <silent> <leader>c :PyReplStrip output<CR>
+	vnoremap <buffer> <silent> <leader>c :'<,'>PyReplStrip output<CR>
 endif
 
 syn match PyReplComment '^# \%(in\|out\|warn\): .*' contains=PyReplRest,PyReplIn,PyReplOut,PyReplWarn
@@ -17,11 +21,30 @@ syn match PyReplIn '# in:' contained
 syn match PyReplOut '# out:' contained
 syn match PyReplWarn '# warn:' contained
 
-if g:pyrepl_set_colors
-	hi PyReplIn ctermfg=green
-	hi PyReplOut ctermfg=darkgrey
-	hi PyReplWarn ctermfg=darkred
-	hi PyReplComment ctermfg=grey
-endif
+fun! s:GetHighlightColor(name, default) abort
+	let l:colorval = synIDattr(synIDtrans(hlID(a:name)), "fg")
+	return colorval == "" ? a:default : colorval
+endfun
 
+fun! s:SetDefaultHighlight(name, value) abort
+	let l:colorval = s:GetHighlightColor(a:name, a:value)
+	execute "hi " . a:name . " ctermfg=" . colorval
+endfun
+
+let s:color_pyrepl_in      = s:GetHighlightColor("PyReplIn", "green")
+let s:color_pyrepl_out     = s:GetHighlightColor("PyReplOut", "darkgrey")
+let s:color_pyrepl_info    = s:GetHighlightColor("PyReplInfo", "yellow")
+let s:color_pyrepl_comment = s:GetHighlightColor("PyReplComment", "grey")
+
+fun! s:SetDefaultColors() abort
+	call s:SetDefaultHighlight("PyReplIn", s:color_pyrepl_in)
+	call s:SetDefaultHighlight("PyReplOut", s:color_pyrepl_out)
+	call s:SetDefaultHighlight("PyReplInfo", s:color_pyrepl_info)
+	call s:SetDefaultHighlight("PyReplComment", s:color_pyrepl_comment)
+endfun
+
+augroup PyReplColors
+	autocmd! * <buffer>
+	autocmd ColorScheme <buffer> call s:SetDefaultColors()
+augroup END
 

--- a/ftplugin/python.vim
+++ b/ftplugin/python.vim
@@ -4,8 +4,12 @@ if !exists('g:pyrepl_map_keys')
 endif
 
 if g:pyrepl_map_keys
-	nnoremap <buffer> <silent> <leader>r :call pyrepl#EvalBuffer()<CR>
-	nnoremap <buffer> <silent> <leader>c :call pyrepl#StripOutput()<CR>
+	nnoremap <buffer> <silent> <leader>ee :PyReplEval<CR>
+	nnoremap <buffer> <silent> <leader>eu :0,PyReplEval<CR>
+	vnoremap <buffer> <silent> <leader>e :'<,'>PyReplEval<CR>
+
+	nnoremap <buffer> <silent> <leader>c :PyReplStrip output<CR>
+	vnoremap <buffer> <silent> <leader>c :'<,'>PyReplStrip output<CR>
 endif
 
 syn match PyReplComment '^# \%(in\|out\|info\): .*' contains=PyReplIn,PyReplOut,PyReplInfo
@@ -13,22 +17,31 @@ syn match PyReplIn '# in:' contained
 syn match PyReplOut '# out:' contained
 syn match PyReplInfo '# info:' contained
 
-fun! s:SetDefaultHighlight(name, value) abort
-	if synIDattr(synIDtrans(hlID(a:name)), "fg") == ""
-		execute "hi " . a:name . " ctermfg=" . a:value
-	endif
+fun! s:GetHighlightColor(name, default) abort
+	let l:colorval = synIDattr(synIDtrans(hlID(a:name)), "fg")
+	return colorval == "" ? a:default : colorval
 endfun
 
+fun! s:SetDefaultHighlight(name, value) abort
+	let l:colorval = s:GetHighlightColor(a:name, a:value)
+	execute "hi " . a:name . " ctermfg=" . colorval
+endfun
+
+let s:color_pyrepl_in      = s:GetHighlightColor("PyReplIn", "green")
+let s:color_pyrepl_out     = s:GetHighlightColor("PyReplOut", "darkgrey")
+let s:color_pyrepl_info    = s:GetHighlightColor("PyReplInfo", "yellow")
+let s:color_pyrepl_comment = s:GetHighlightColor("PyReplComment", "grey")
+
 fun! s:SetDefaultColors() abort
-	call s:SetDefaultHighlight("PyReplIn", "green")
-	call s:SetDefaultHighlight("PyReplOut", "darkgrey")
-	call s:SetDefaultHighlight("PyReplInfo", "yellow")
-	call s:SetDefaultHighlight("PyReplComment", "grey")
+	call s:SetDefaultHighlight("PyReplIn", s:color_pyrepl_in)
+	call s:SetDefaultHighlight("PyReplOut", s:color_pyrepl_out)
+	call s:SetDefaultHighlight("PyReplInfo", s:color_pyrepl_info)
+	call s:SetDefaultHighlight("PyReplComment", s:color_pyrepl_comment)
 endfun
 
 augroup PyReplColors
-	autocmd!
-	autocmd ColorScheme * call s:SetDefaultColors()
+	autocmd! * <buffer>
+	autocmd ColorScheme <buffer> call s:SetDefaultColors()
 augroup END
 
 call s:SetDefaultColors()

--- a/plugin/pyrepl.vim
+++ b/plugin/pyrepl.vim
@@ -49,10 +49,18 @@ fun! s:EvalCode(start, stop) abort
 	let l:buffersize = line('$')
 	call s:StripComments(a:start, a:stop, 'output')
 	let l:true_stop = a:stop - (l:buffersize - line('$'))
+
+	let l:old_pypath = $PYTHONPATH
 	
 	let l:source = join(getline(a:start, true_stop), "\n")
 	let l:command = g:pyrepl_interpreter . " -m pyrepl " . g:pyrepl_timeout . " " . (a:start - 1)
-	let l:output = system(command, source)
+
+	try
+		let $PYTHONPATH .= ":" . resolve(expand("%:p:h"))
+		let l:output = system(command, source)
+	finally
+		let $PYTHONPATH = old_pypath
+	endtry
 
 	for [lineno, text] in json_decode(output)
 		if lineno == -1

--- a/plugin/pyrepl.vim
+++ b/plugin/pyrepl.vim
@@ -1,28 +1,3 @@
-syn match PyReplComment '^# \%(in\|out\|info\): .*' contains=PyReplIn,PyReplOut,PyReplInfo
-syn match PyReplIn '# in:' contained
-syn match PyReplOut '# out:' contained
-syn match PyReplInfo '# info:' contained
-
-fun! s:SetDefaultHighlight(name, value) abort
-	if synIDattr(synIDtrans(hlID(a:name)), "fg") == ""
-		execute "hi " . a:name . " ctermfg=" . a:value
-	endif
-endfun
-
-fun! s:SetDefaultColors() abort
-	call s:SetDefaultHighlight("PyReplIn", "green")
-	call s:SetDefaultHighlight("PyReplOut", "darkgrey")
-	call s:SetDefaultHighlight("PyReplInfo", "yellow")
-	call s:SetDefaultHighlight("PyReplComment", "grey")
-endfun
-
-augroup PyReplColors
-	autocmd!
-	autocmd ColorScheme * call s:SetDefaultColors()
-augroup END
-
-call s:SetDefaultColors()
-
 let $PYTHONPATH .= ":" . resolve(expand("<sfile>:p:h:h") . '/src')
 
 if !exists("g:pyrepl_timeout")

--- a/plugin/pyrepl.vim
+++ b/plugin/pyrepl.vim
@@ -1,0 +1,94 @@
+syn match PyReplComment '^# \%(in\|out\|info\): .*' contains=PyReplIn,PyReplOut,PyReplInfo
+syn match PyReplIn '# in:' contained
+syn match PyReplOut '# out:' contained
+syn match PyReplInfo '# info:' contained
+
+fun! s:SetDefaultHighlight(name, value) abort
+	if synIDattr(synIDtrans(hlID(a:name)), "fg") == ""
+		execute "hi " . a:name . " ctermfg=" . a:value
+	endif
+endfun
+
+fun! s:SetDefaultColors() abort
+	call s:SetDefaultHighlight("PyReplIn", "green")
+	call s:SetDefaultHighlight("PyReplOut", "darkgrey")
+	call s:SetDefaultHighlight("PyReplInfo", "yellow")
+	call s:SetDefaultHighlight("PyReplComment", "grey")
+endfun
+
+augroup PyReplColors
+	autocmd!
+	autocmd ColorScheme * call s:SetDefaultColors()
+augroup END
+
+call s:SetDefaultColors()
+
+let $PYTHONPATH .= ":" . resolve(expand("<sfile>:p:h:h") . '/src')
+
+if !exists("g:pyrepl_timeout")
+	let g:pyrepl_timeout = 1
+endif
+
+if !exists("g:pyrepl_interpreter")
+	if executable("python3")
+		let g:pyrepl_interpreter = "python3"
+	else
+		let g:pyrepl_interpreter = "python"
+	endif
+endif
+
+fun! s:Clamp(value, lower, upper) abort
+	return max([a:lower, min([a:value, a:upper])])
+endfun
+
+fun! s:DelComments(start, stop, keywords) abort
+	let [l:bufnum, l:lnum, l:col, l:off, l:curswant] = getcurpos()
+	let l:mid = s:Clamp(l:lnum, a:start, a:stop)
+
+	sil execute l:mid . "," . a:stop .  "g/^# \\%\\(" . a:keywords . "\\): /d"
+	sil execute a:start . "," . l:mid . "g/^# \\%\\(" . a:keywords . "\\): /d|let l:lnum -= 1"
+
+	call setpos(".", [bufnum, lnum, col, off, curswant])
+endfun
+
+fun! s:StripComments(start, stop, ...) abort
+	let l:mode = get(a:, 1, 'output')
+
+	if l:mode == "all"
+		let l:regex = "in\\|out\\|info"
+	elseif l:mode == "output"
+		let l:regex = "out\\|info"
+	elseif l:mode == "input"
+		let l:regex = "in"
+	else
+		echoerr "Invalid Option: " . l:mode
+	endif
+	call s:DelComments(a:start, a:stop, l:regex)
+endfun
+
+fun! s:StripOptions(ArgLead, CmdLine, CursorPos) abort
+	return join(["all", "input", "output"], "\n")
+endfun
+
+fun! s:EvalCode(start, stop) abort
+	let l:buffersize = line('$')
+	call s:StripComments(a:start, a:stop, 'output')
+	let l:true_stop = a:stop - (l:buffersize - line('$'))
+	
+	let l:source = join(getline(a:start, true_stop), "\n")
+	let l:command = g:pyrepl_interpreter . " -m pyrepl " . g:pyrepl_timeout
+	let l:output = system(command, source)
+
+	for [lineno, text] in json_decode(output)
+		if lineno == -1
+			echohl ErrorMsg
+			echomsg text
+			echohl None
+			return
+		endif
+		call append(lineno, split(text, "\n", 1))
+	endfor
+endfun
+
+command -range=% -bar PyReplEval call s:EvalCode(<line1>, <line2>)
+command -range=% -bar -nargs=? -complete=custom,s:StripOptions PyReplStrip call s:StripComments(<line1>, <line2>, <f-args>)

--- a/plugin/pyrepl.vim
+++ b/plugin/pyrepl.vim
@@ -76,7 +76,7 @@ fun! s:EvalCode(start, stop) abort
 	let l:true_stop = a:stop - (l:buffersize - line('$'))
 	
 	let l:source = join(getline(a:start, true_stop), "\n")
-	let l:command = g:pyrepl_interpreter . " -m pyrepl " . g:pyrepl_timeout
+	let l:command = g:pyrepl_interpreter . " -m pyrepl " . g:pyrepl_timeout . " " . (a:start - 1)
 	let l:output = system(command, source)
 
 	for [lineno, text] in json_decode(output)

--- a/plugin/pyrepl.vim
+++ b/plugin/pyrepl.vim
@@ -22,3 +22,73 @@ augroup PyReplColors
 augroup END
 
 call s:SetDefaultColors()
+
+let $PYTHONPATH .= ":" . resolve(expand("<sfile>:p:h:h") . '/src')
+
+if !exists("g:pyrepl_timeout")
+	let g:pyrepl_timeout = 1
+endif
+
+if !exists("g:pyrepl_interpreter")
+	if executable("python3")
+		let g:pyrepl_interpreter = "python3"
+	else
+		let g:pyrepl_interpreter = "python"
+	endif
+endif
+
+fun! s:Clamp(value, lower, upper) abort
+	return max([a:lower, min([a:value, a:upper])])
+endfun
+
+fun! s:DelComments(start, stop, keywords) abort
+	let [l:bufnum, l:lnum, l:col, l:off, l:curswant] = getcurpos()
+	let l:mid = s:Clamp(l:lnum, a:start, a:stop)
+
+	sil execute l:mid . "," . a:stop .  "g/^# \\%\\(" . a:keywords . "\\): /d"
+	sil execute a:start . "," . l:mid . "g/^# \\%\\(" . a:keywords . "\\): /d|let l:lnum -= 1"
+
+	call setpos(".", [bufnum, lnum, col, off, curswant])
+endfun
+
+fun! s:StripComments(start, stop, ...) abort
+	let l:mode = get(a:, 1, 'output')
+
+	if l:mode == "all"
+		let l:regex = "in\\|out\\|info"
+	elseif l:mode == "output"
+		let l:regex = "out\\|info"
+	elseif l:mode == "input"
+		let l:regex = "in"
+	else
+		echoerr "Invalid Option: " . l:mode
+	endif
+	call s:DelComments(a:start, a:stop, l:regex)
+endfun
+
+fun! s:StripOptions(ArgLead, CmdLine, CursorPos) abort
+	return join(["all", "input", "output"], "\n")
+endfun
+
+fun! s:EvalCode(start, stop) abort
+	let l:buffersize = line('$')
+	call s:StripComments(a:start, a:stop, 'output')
+	let l:true_stop = a:stop - (l:buffersize - line('$'))
+	
+	let l:source = join(getline(a:start, true_stop), "\n")
+	let l:command = g:pyrepl_interpreter . " -m pyrepl " . g:pyrepl_timeout
+	let l:output = system(command, source)
+
+	for [lineno, text] in json_decode(output)
+		if lineno == -1
+			echohl ErrorMsg
+			echomsg text
+			echohl None
+			return
+		endif
+		call append(lineno, split(text, "\n", 1))
+	endfor
+endfun
+
+command -range=% -bar PyReplEval call s:EvalCode(<line1>, <line2>)
+command -range=% -bar -nargs=? -complete=custom,s:StripOptions PyReplStrip call s:StripComments(<line1>, <line2>, <f-args>)

--- a/src/pyrepl/__main__.py
+++ b/src/pyrepl/__main__.py
@@ -10,8 +10,14 @@ def main():
 	except:
 		timeout = DEFAULT_TIMEOUT
 
+	try:
+		offset = int(sys.argv[2]) 
+		assert offset >= 0
+	except:
+		offset = 0
+
 	code = sys.stdin.read()
-	result = run_code(code, timeout)
+	result = run_code(code, timeout, offset)
 	write_result(result)
 
 if __name__ == "__main__":

--- a/src/pyrepl/runner.py
+++ b/src/pyrepl/runner.py
@@ -11,7 +11,7 @@ def write_result(output):
 def build_error(msg):
 	return [[-1, msg]]
 
-def run_code(code, timeout, offset):
+def run_code(code, timeout, offset=0):
 	code = "\n" * offset + code
 	with IOBuffer() as (fdin, fdout):
 		interpreter = Interpreter(fdin, fdout)

--- a/src/pyrepl/runner.py
+++ b/src/pyrepl/runner.py
@@ -11,7 +11,8 @@ def write_result(output):
 def build_error(msg):
 	return [[-1, msg]]
 
-def run_code(code, timeout):
+def run_code(code, timeout, offset):
+	code = "\n" * offset + code
 	with IOBuffer() as (fdin, fdout):
 		interpreter = Interpreter(fdin, fdout)
 		thread = Thread(target=interpreter.eval, args=(code,))


### PR DESCRIPTION
Creates commands `PyReplEval` and `PyReplStrip` for usage over the previous `pyrepl#XYZ` functions. These also support ranges.

Side Fixes:
 - Highlight colors are preserved on colorscheme set (even if not our defaults)
 - PYTHONPATH is properly updated to include `__main__`'s base dir
 - Autocommands are buffer-local